### PR TITLE
Test for UTF8 encode exception

### DIFF
--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -51,5 +51,13 @@ class JsonParserTest extends TestCase
         $arr = ["a" => INF];
         JsonParser::jsonEncode($arr);
     }
+    
+    public function testEncodeUTF8Exception()
+    {
+        $this->expectException(Utf8Exception::class);
+        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
+
+        JsonHandler::encode("\xB1\x31");
+    }
 
 }

--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -57,7 +57,16 @@ class JsonParserTest extends TestCase
         $this->expectException(Utf8Exception::class);
         $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
 
-        JsonHandler::encode("\xB1\x31");
+        JsonParser::jsonEncode("\xB1\x31");
+    }
+    
+    public function testDecodeDepthException()
+    {
+        $this->expectException(DepthException::class);
+        $this->expectExceptionMessage('Maximum stack depth exceeded');
+
+        $sample = '{ "layer1": {"layer2": {"layer3": "leaf"} } }';
+        JsonParser::jsonDecode($sample, true, 2);
     }
 
 }


### PR DESCRIPTION
Added test t covert UTF8 encoding exception
It also seems like the code bellow does not test the state missmiacht exception

```php
public function testStateMismatchError(){
        $this->expectException(StateMismatchException::class);
        JsonParser::jsonDecode('{"j": 1 ] }');
    }
```